### PR TITLE
make corner fully transparent to fix #11

### DIFF
--- a/src/stylesheet.css
+++ b/src/stylesheet.css
@@ -7,7 +7,7 @@
     transition-duration: 500ms;
 }
 #panel.transparent-top-bar--transparent .panel-corner {
-    -panel-corner-background-color: rgba(0, 0, 0, 0.35);
+    -panel-corner-background-color: rgba(0, 0, 0, 0);
 }
 #panel.transparent-top-bar--transparent .panel-button {
     color: #eee;


### PR DESCRIPTION
If the corner under .transparent-top-bar--transparent is fully transparent,  it should effectively disappear so #11 could be fixed.
It won't affect how it looks under .transparent-top-bar--solid so it should work just fine for other cases.