### PR TITLE
Support for Multi Monitors Add-On

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -48,8 +48,7 @@ class Extension {
         this._actorSignalIds = null;
         this._windowSignalIds = null;
 
-        Main.panel.remove_style_class_name('transparent-top-bar--solid');
-        Main.panel.remove_style_class_name('transparent-top-bar--transparent');
+        this._setAllTransparent(false);
     }
 
     _onWindowActorAdded(container, metaWindowActor) {
@@ -69,7 +68,7 @@ class Extension {
 
     _updateTransparent() {
         if (Main.panel.has_style_pseudo_class('overview') || !Main.sessionMode.hasWindows) {
-            this._setTransparent(true);
+            this._setAllTransparent(true);
             return;
         }
 
@@ -81,31 +80,79 @@ class Extension {
         const workspaceManager = global.workspace_manager;
         const activeWorkspace = workspaceManager.get_active_workspace();
         const windows = activeWorkspace.list_windows().filter(metaWindow => {
-            return metaWindow.is_on_primary_monitor()
-                    && metaWindow.showing_on_its_workspace()
-                    && !metaWindow.is_hidden()
-                    && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
+            return  metaWindow.showing_on_its_workspace()
+                && !metaWindow.is_hidden()
+                && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
+        })
+
+        var monitors = {};
+        windows.forEach(window => {
+            if (monitors[window.get_monitor()]) {
+                monitors[window.get_monitor()].push(window)
+            } else {
+                monitors[window.get_monitor()] = [window];
+            }
         });
 
-        // Check if at least one window is near enough to the panel.
-        const panelTop = Main.panel.get_transformed_position()[1];
-        const panelBottom = panelTop + Main.panel.get_height();
-        const scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        const isNearEnough = windows.some(metaWindow => {
-            const verticalPosition = metaWindow.get_frame_rect().y;
-            return verticalPosition < panelBottom + 5 * scale;
-        });
+        Main.layoutManager.monitors.forEach(monitor => {
+            const panel = (() => {
+                if (monitor.index == Main.layoutManager.primaryMonitor.index) {
+                    return Main.panel;
+                } else if (Main.mmPanel) {
+                    return Main.mmPanel[monitor.index - 1];
+                }
+                return null;
+            })();
 
-        this._setTransparent(!isNearEnough);
+            if (!panel) {
+                return;
+            }
+
+            const monitor_windows = monitors[monitor.index];
+            if (monitor_windows) {
+                const panelTop = panel.get_transformed_position()[1];
+                const panelBottom = panelTop + panel.get_height();
+                const scale = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+                const isNearEnough = monitor_windows.some(metaWindow => {
+                    const verticalPosition = metaWindow.get_frame_rect().y;
+                    return verticalPosition < panelBottom + 5 * scale;
+                });
+
+                this._setTransparent(!isNearEnough, panel);
+            } else {
+                this._setTransparent(true, panel);
+            }
+        });
     }
 
-    _setTransparent(transparent) {
+    _setTransparent(transparent, panel) {
+
         if (transparent) {
-            Main.panel.remove_style_class_name('transparent-top-bar--solid');
-            Main.panel.add_style_class_name('transparent-top-bar--transparent');
+            panel.remove_style_class_name('transparent-top-bar--solid');
+            panel.add_style_class_name('transparent-top-bar--transparent');
         } else {
-            Main.panel.add_style_class_name('transparent-top-bar--solid');
-            Main.panel.remove_style_class_name('transparent-top-bar--transparent');
+            panel.add_style_class_name('transparent-top-bar--solid');
+            panel.remove_style_class_name('transparent-top-bar--transparent');
+        }
+    }
+
+    _setAllTransparent(transparent) {
+        var panels = [Main.panel];
+        if (Main.mmPanel) {
+            panels = panels.concat(Main.mmPanel);
+        }
+
+        if (transparent) {
+            panels.forEach(panel => {
+                panel.remove_style_class_name('transparent-top-bar--solid');
+                panel.add_style_class_name('transparent-top-bar--transparent');
+            })
+
+        } else {
+            panels.forEach(panel => {
+                panel.add_style_class_name('transparent-top-bar--solid');
+                panel.remove_style_class_name('transparent-top-bar--transparent');
+            })
         }
     }
 };


### PR DESCRIPTION
This PR adds support for the additional top bars shown by the popular Multi Monitors Add-On by spin83 [1].
The top bars of each monitor are handled independently. When maximizing a window, only the top bar of the monitor on which the window is displayed becomes opaque. Of course, this doesn't change how this extension works when the Multi Monitors Add-On is not installed.

As I only have two monitors connected to my computer, I could only test my changes with one additional top panel. However, more monitors should also work the same.

This PR also resolves issue #7 when the Multi Monitors Add-On extension is used.

[1] https://github.com/spin83/multi-monitors-add-on