### PR TITLE
GNOME 42 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,8 @@
   "name": "Transparent Top Bar",
   "shell-version": [
     "40",
-    "41"
+    "41",
+    "42"
   ],
   "url": "https://github.com/zhanghai/gnome-shell-extension-transparent-top-bar",
   "uuid": "transparent-top-bar@zhanghai.me"


### PR DESCRIPTION
No code changes required as far as I can tell, everything seems to work as it did before
Tested on Debian Experimental (GNOME 42)