### PR TITLE
GNOME 45 Porting

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -3,7 +3,7 @@ import St from 'gi://St';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-class Extension {
+export default class TransparentTopBarExtension {
     constructor() {
         this._actorSignalIds = null;
         this._windowSignalIds = null;
@@ -107,7 +107,3 @@ class Extension {
         }
     }
 };
-
-function init() {
-    return new Extension();
-}

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,7 @@
-const { Meta, St } = imports.gi;
+import Meta from 'gi://Meta';
+import St from 'gi://St';
 
-const Main = imports.ui.main;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 class Extension {
     constructor() {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "description": "Bring back the transparent top bar when free-floating in GNOME Shell 3.32.\n\nThis basically comes from the feature implementation removed in GNOME Shell 3.32, and I modified the code a bit to make it an extension. Enjoy!",
   "name": "Transparent Top Bar",
   "shell-version": [
-    "44"
+    "45"
   ],
   "url": "https://github.com/zhanghai/gnome-shell-extension-transparent-top-bar",
   "uuid": "transparent-top-bar@zhanghai.me"


### PR DESCRIPTION
Self-explanatory, ports the extension to GNOME 45.

For this extension, it just required using the new ESM import style, a metadata update, and exporting a default class. `init()` isn't required anymore, so that was removed.

As GNOME 45 requires ESM imports, these can't be used at the same time as the old-style imports, so the extension can't support pre-45 and 45+ at the same time.

Tested on Fedora Rawhide with GNOME 45 Beta, works perfectly