### PR TITLE
Removed signal causing transparency to get stuck

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -34,10 +34,6 @@ export default class TransparentTopBarExtension extends Extension {
             global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
         ]);
 
-        this._actorSignalIds.set(global.window_manager, [
-            global.window_manager.connect('switch-workspace', this._updateTransparent.bind(this))
-        ]);
-
         this._updateTransparent();
     }
 


### PR DESCRIPTION
This is an alternative to #36

I was testing monkey-patching `_finishWorkspaceSwitch`, and realised that removing the workspace switch signal fixes the problem. Apparently the signal isn't necessary on GNOME 44+ anymore, from my testing.

Originally written for GNOME 44, then tested on GNOME 45