### PR TITLE
Support GNOME 46

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -5,8 +5,6 @@ import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
-
 export default class TransparentTopBarExtension extends Extension {
     constructor(metadata) {
         super(metadata);
@@ -32,17 +30,10 @@ export default class TransparentTopBarExtension extends Extension {
             this._onWindowActorAdded(metaWindowActor.get_parent(), metaWindowActor);
         }
 
-        if (ShellVersion >= 46) {
-            this._actorSignalIds.set(global.window_group, [
-                global.window_group.connect('child-added', this._onWindowActorAdded.bind(this)),
-                global.window_group.connect('child-removed', this._onWindowActorRemoved.bind(this))
-            ]);
-        } else {
-            this._actorSignalIds.set(global.window_group, [
-                global.window_group.connect('actor-added', this._onWindowActorAdded.bind(this)),
-                global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
-            ]);
-        }
+        this._actorSignalIds.set(global.window_group, [
+            global.window_group.connect('child-added', this._onWindowActorAdded.bind(this)),
+            global.window_group.connect('child-removed', this._onWindowActorRemoved.bind(this))
+        ]);
 
         this._updateTransparent();
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -2,7 +2,10 @@ import Meta from 'gi://Meta';
 import St from 'gi://St';
 
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
 
 export default class TransparentTopBarExtension extends Extension {
     constructor(metadata) {
@@ -29,10 +32,17 @@ export default class TransparentTopBarExtension extends Extension {
             this._onWindowActorAdded(metaWindowActor.get_parent(), metaWindowActor);
         }
 
-        this._actorSignalIds.set(global.window_group, [
-            global.window_group.connect('actor-added', this._onWindowActorAdded.bind(this)),
-            global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
-        ]);
+        if (ShellVersion >= 46) {
+            this._actorSignalIds.set(global.window_group, [
+                global.window_group.connect('child-added', this._onWindowActorAdded.bind(this)),
+                global.window_group.connect('child-removed', this._onWindowActorRemoved.bind(this))
+            ]);
+        } else {
+            this._actorSignalIds.set(global.window_group, [
+                global.window_group.connect('actor-added', this._onWindowActorAdded.bind(this)),
+                global.window_group.connect('actor-removed', this._onWindowActorRemoved.bind(this))
+            ]);
+        }
 
         this._updateTransparent();
     }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "description": "Bring back the transparent top bar when free-floating in GNOME Shell 3.32.\n\nThis basically comes from the feature implementation removed in GNOME Shell 3.32, and I modified the code a bit to make it an extension. Enjoy!",
   "name": "Transparent Top Bar",
   "shell-version": [
-    "45"
+    "45", "46"
   ],
   "url": "https://github.com/zhanghai/gnome-shell-extension-transparent-top-bar",
   "uuid": "transparent-top-bar@zhanghai.me"

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "description": "Bring back the transparent top bar when free-floating in GNOME Shell 3.32.\n\nThis basically comes from the feature implementation removed in GNOME Shell 3.32, and I modified the code a bit to make it an extension. Enjoy!",
   "name": "Transparent Top Bar",
   "shell-version": [
-    "45", "46"
+    "46"
   ],
   "url": "https://github.com/zhanghai/gnome-shell-extension-transparent-top-bar",
   "uuid": "transparent-top-bar@zhanghai.me"


### PR DESCRIPTION
Fairly simple port, the `actor-added` and `actor-removed` signals are now `child-added` and `child-removed`.