### PR TITLE
Add support for GNOME 48

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,8 @@
   "name": "Transparent Top Bar",
   "shell-version": [
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/zhanghai/gnome-shell-extension-transparent-top-bar",
   "uuid": "transparent-top-bar@zhanghai.me"


### PR DESCRIPTION
No changes required, works perfectly
Tested on GNOME 48 beta, but no more breaking changes are coming