### PR TITLE
Filter out fake windows created by Desktop Icons NG

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -83,7 +83,8 @@ export default class TransparentTopBarExtension extends Extension {
             return metaWindow.is_on_primary_monitor()
                     && metaWindow.showing_on_its_workspace()
                     && !metaWindow.is_hidden()
-                    && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP;
+                    && metaWindow.get_window_type() !== Meta.WindowType.DESKTOP
+                    && metaWindow.gtk_application_id !== 'com.rastersoft.ding';
         });
 
         // Check if at least one window is near enough to the panel.


### PR DESCRIPTION
Ubuntu 26.04's version of Desktop Icons NG creates a fake window that fills the screen, causing this extension to think a real window is always in contact with the top bar.

Filter out windows with the extension's ID to fix it.

Fixes #52 